### PR TITLE
fiodb: Ensure tablename is properly quoted in sql queries

### DIFF
--- a/fiodb.py
+++ b/fiodb.py
@@ -26,11 +26,11 @@ def sql_create_table(con, tablename):
         return 1
     print(tablename)
     cur = con.cursor()
-    cmd = "CREATE TABLE IF NOT EXISTS {} (".format(tablename)
+    cmd = "CREATE TABLE IF NOT EXISTS '{}' (".format(tablename)
     cmd += " threads int NOT NULL)"
     cur.execute(cmd)
 
-    cmd = "insert INTO {} (threads) Values (1),(2),(4),(8),(12),(16),(24)".format(tablename)
+    cmd = "insert INTO '{}' (threads) Values (1),(2),(4),(8),(12),(16),(24)".format(tablename)
     cur.execute(cmd)
     con.commit()
     print("Sql: Table {} created".format(tablename))
@@ -44,7 +44,7 @@ def sql_create_table(con, tablename):
 
 def sql_print_table(con, tablename):
     cur = con.cursor()
-    cmd = "SELECT * from {}".format(tablename)
+    cmd = "SELECT * from '{}'".format(tablename)
     cur.execute(cmd)
     rows = cur.fetchall()
     for row in rows:
@@ -52,14 +52,14 @@ def sql_print_table(con, tablename):
 
 def sql_update_table(con, tablename, column, threadID, value):
     cur = con.cursor()
-    cmd = "UPDATE {} SET {} = {} WHERE threads = {}".format(tablename, column, value, threadID)
+    cmd = "UPDATE '{}' SET {} = {} WHERE threads = {}".format(tablename, column, value, threadID)
     print(cmd)
     cur.execute(cmd)
     con.commit()
 
 def sql_add_column(con, tablename, columnname):
     cur = con.cursor()
-    cmd = "ALTER TABLE {} ADD {} float".format(tablename, columnname)
+    cmd = "ALTER TABLE '{}' ADD {} float".format(tablename, columnname)
     print(cmd)
     cur.execute(cmd)
     con.commit()


### PR DESCRIPTION
'tablename' is derived from job name and if the job name contains
special charecters like '-' then following error is reported.

Traceback (most recent call last):
  File "./fioperf.py", line 185, in <module>
    fio_setup_env()
  File "./fioperf.py", line 176, in fio_setup_env
    fio_setup_sql(fiosql_con, section, fiosql_column, fiotests)
  File "./fioperf.py", line 117, in fio_setup_sql
    sql_add_column(fiosql_con, tablename, col_read)
  File "/home/vajain21/fioperf/fiodb.py", line 64, in sql_add_column
    cur.execute(cmd)
sqlite3.OperationalError: near "-": syntax error

Fix this by ensuring that tablename is sql queries is always wrapped
in single-quotes

Signed-off-by: Vaibhav Jain <vaibhav@linux.ibm.com>